### PR TITLE
Add capability to specify stream resolution for detection

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
@@ -74,13 +74,19 @@
     [Parameter]
     public int VideoHeigth { get; set; } = 200;
 
+    [Parameter]
+    public int? StreamHeight { get; set; } = null;
+
+    [Parameter]
+    public int? StreamWidth { get; set; } = null;
+
     public string BarcodeText { get; set; }
 
     List<VideoInputDevice> videoInputDevices;
     protected override async Task OnInitializedAsync()
     {
         videoInputDevices = await JsInteropClass.GetVideoInputDevices(JSRuntime, "get");
-        
+
         JsInteropClass.BarcodeReceived += ReceivedBarcodeText;
         if (StartCameraAutomatically && videoInputDevices.Count > 0) {
             JsInteropClass.SetVideoInputDevice(JSRuntime, videoInputDevices[0].DeviceId);
@@ -94,13 +100,14 @@
     }
     private void StartDecoding()
     {
-
-        JsInteropClass.StartDecoding(JSRuntime, "zxingVideo");
+        var width = StreamWidth.HasValue ? StreamWidth.Value : 0;
+        var height = StreamHeight.HasValue ? StreamHeight.Value : 0;
+        JsInteropClass.StartDecoding(JSRuntime, "zxingVideo", width, height);
     }
     private void StopDecoding()
     {
         BarcodeReceivedEventArgs resetBarcodeArgs = new BarcodeReceivedEventArgs();
-         resetBarcodeArgs.BarcodeText = "";
+        resetBarcodeArgs.BarcodeText = "";
         resetBarcodeArgs.TimeReceived = new DateTime();
         ReceivedBarcodeText(resetBarcodeArgs);
         JsInteropClass.StopDecoding(JSRuntime);

--- a/BlazorBarcodeScanner.ZXing.JS/JsInteropClass.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/JsInteropClass.cs
@@ -15,8 +15,8 @@ namespace BlazorBarcodeScanner.ZXing.JS
                 "BlazorBarcodeScanner.listVideoInputDevices",
                 message);
         }
-        public static void StartDecoding(IJSRuntime jSRuntime, string videoElementId) {
-            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.startDecoding", videoElementId);
+        public static void StartDecoding(IJSRuntime jSRuntime, string videoElementId, int width, int height) {
+            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.startDecoding", videoElementId, width, height);
         }
         public static void StopDecoding(IJSRuntime jSRuntime)
         {

--- a/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
+++ b/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
@@ -63,8 +63,21 @@ window.BlazorBarcodeScanner = {
     setSelectedDeviceId: function (deviceId) {
         this.selectedDeviceId = deviceId;
     },
-    startDecoding: function (videoElementId) {
-        this.codeReader.decodeFromVideoDevice(this.selectedDeviceId, videoElementId, (result, err) => {
+    startDecoding: function (videoElementId, width, height) {
+        var videoConstraints = {};
+
+        if (!this.selectedDeviceId) {
+            videoConstraints["facingMode"] = 'environment';
+        }
+        else {
+            videoConstraints["deviceId"] = { exact: this.selectedDeviceId };
+        }
+
+        if (width) videoConstraints["width"] = { ideal: width };
+        if (height) videoConstraints["height"] = { ideal: height };
+
+        console.log("Starting decoding with " + videoConstraints);
+        this.codeReader.decodeFromConstraints({ video: videoConstraints }, videoElementId, (result, err) => {
             if (result) {
                 console.log(result);
                 DotNet.invokeMethodAsync('BlazorBarcodeScanner.ZXing.JS', 'ReceiveBarcode', result.text)

--- a/README.md
+++ b/README.md
@@ -77,5 +77,15 @@ Library raises a custom event when barcode scanner reads a value from video stre
     }
 ```
 
+### Setting stream quality
+While keeping resolution low speeds up image processing, it might yield poor detection performance due to the limited image quality.
+
+In order to allow the application to trade speed for quality, the stream resolution can be set by the application through the following `custom parameters`:
+  - StreamWidth
+  - StreamHeight
+If set to `null` or `0`, a default (browser dependent?) resolution is applied (e.g. 640px by 480px). If set to any number `>0`, the camera stream is requested with the given setting. The settings are used as `ideal` constraint for `getUserMedia` (see [constraints doc](https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints#specifying_a_range_of_values). Doing so allows for achieving highest resolution by requesting rediculous high numbers for either dimension, causing  the browser to fall back to the maximum feasable for the device of choice.
+
+**Warning**: While increasing the stream resolution might improve your application's code reading performance, it might greatly affect the over all user experience (e.g. through a drop of the frame rate, increased CPU usage, bad battery life, ...) 
+
 ### Supported Formats
 This library uses auto-detect feature of zxing-js library. It supports variety of barcode types. For more information: [zxing-js supported types](https://github.com/zxing-js/library#supported-formats)


### PR DESCRIPTION
While playing around, I found the detection performance quite poor compared to ZXing.Net. So I tried to figure out why this could be. Poking around in the video settings I found that the stream was started with a resolution of 640x480 only, regardless what size I set up for the video. I further found, that increasing resolution greatly improved detection quality.

Thus I found it might be useful to be able to setup the stream's resolution to whatever suits the application.