### PR TITLE
Add API that allows the parent to grab a frame from the stream being decoded

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
@@ -26,8 +26,9 @@
     }
 
     <div id="zxingVideoContainer">
-        <video id="zxingVideo" width="@VideoWidth" height="@VideoHeight"></video>
+        <video @ref="_video" width="@VideoWidth" height="@VideoHeight"></video>
     </div>
+    <canvas @ref="_canvas" style="display:none;"/>
 
     @if (ShowVideoDeviceList)
     {

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
@@ -1,5 +1,4 @@
 ﻿@using Microsoft.JSInterop
-@inject IJSRuntime JSRuntime
 
 <section class="zxing-container" id="zxingContent">
     @if (string.IsNullOrWhiteSpace(Title))
@@ -40,7 +39,7 @@
         {
             <div id="sourceSelectPanel">
                 <label for="zxingSourceSelect">Change video source:</label>
-                <select id="zxingSourceSelect" class="zxing-video-input" @onchange="ChangeVideoInputSource">
+                <select id="zxingSourceSelect" class="zxing-video-input" @onchange="OnVideoInputSourceChanged">
                     @foreach (var videoInputDevice in _videoInputDevices)
                     {
                         <option value="@videoInputDevice.DeviceId">@videoInputDevice.Label</option>

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace BlazorBarcodeScanner.ZXing.JS
@@ -66,7 +65,10 @@ namespace BlazorBarcodeScanner.ZXing.JS
         public string SelectedVideoInputId { get; private set; } = string.Empty;
 
         private List<VideoInputDevice> _videoInputDevices;
+
         private BarcodeReaderInterop _backend;
+        private ElementReference _video;
+        private ElementReference _canvas;
 
         protected override async Task OnInitializedAsync()
         {
@@ -98,7 +100,15 @@ namespace BlazorBarcodeScanner.ZXing.JS
         {
             var width = StreamWidth.HasValue ? StreamWidth.Value : 0;
             var height = StreamHeight.HasValue ? StreamHeight.Value : 0;
-            _backend.StartDecoding("zxingVideo", width, height);
+            _backend.StartDecoding(_video, width, height);
+        }
+
+        public async Task<string> Capture()
+        {
+            var start = DateTime.Now;
+            var image = await _backend.Capture(_canvas);
+            Console.WriteLine($"Captured in {(DateTime.Now - start).TotalMilliseconds} ms");
+            return image;
         }
 
         public void StopDecoding()

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -59,6 +59,8 @@ namespace BlazorBarcodeScanner.ZXing.JS
         [Parameter]
         public EventCallback<BarcodeReceivedEventArgs> OnBarcodeReceived { get; set; }
 
+        public bool IsDecoding { get; protected set; } = false;
+
         public string BarcodeText { get; set; }
 
         public IEnumerable<VideoInputDevice> VideoInputDevices => _videoInputDevices;
@@ -105,6 +107,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
             var width = StreamWidth ?? 0;
             var height = StreamHeight ?? 0;
             _backend.StartDecoding(_video, width, height);
+            IsDecoding = true;
         }
 
         public async Task<string> Capture()
@@ -119,6 +122,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
         {
             BarcodeReaderInterop.OnBarcodeReceived(string.Empty);
             _backend.StopDecoding();
+            IsDecoding = false;
         }
 
         public void UpdateResolution()

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace BlazorBarcodeScanner.ZXing.JS
 {
-    public partial class BarcodeReader
+    public partial class BarcodeReader : ComponentBase
     {
         [Parameter]
         public string Title { get; set; } = "Scan Barcode from Camera";
@@ -63,6 +64,9 @@ namespace BlazorBarcodeScanner.ZXing.JS
         public IEnumerable<VideoInputDevice> VideoInputDevices => _videoInputDevices;
 
         public string SelectedVideoInputId { get; private set; } = string.Empty;
+        
+        [Inject]
+        protected IJSRuntime JSRuntime { get; set; }
 
         private List<VideoInputDevice> _videoInputDevices;
 
@@ -98,8 +102,8 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         public void StartDecoding()
         {
-            var width = StreamWidth.HasValue ? StreamWidth.Value : 0;
-            var height = StreamHeight.HasValue ? StreamHeight.Value : 0;
+            var width = StreamWidth ?? 0;
+            var height = StreamHeight ?? 0;
             _backend.StartDecoding(_video, width, height);
         }
 
@@ -113,17 +117,12 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         public void StopDecoding()
         {
-            BarcodeReceivedEventArgs resetBarcodeArgs = new BarcodeReceivedEventArgs();
-            resetBarcodeArgs.BarcodeText = "";
-            resetBarcodeArgs.TimeReceived = new DateTime();
-            ReceivedBarcodeText(resetBarcodeArgs);
+            BarcodeReaderInterop.OnBarcodeReceived(string.Empty);
             _backend.StopDecoding();
         }
 
         public void UpdateResolution()
         {
-            var width = StreamWidth.HasValue ? StreamWidth.Value : 0;
-            var height = StreamHeight.HasValue ? StreamHeight.Value : 0;
             RestartDecoding();
         }
 
@@ -149,7 +148,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         private async void ReceivedBarcodeText(BarcodeReceivedEventArgs args)
         {
-            this.BarcodeText = args.BarcodeText;
+            BarcodeText = args.BarcodeText;
             await OnBarcodeReceived.InvokeAsync(args);
             StateHasChanged();
         }
@@ -161,7 +160,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
             SelectedVideoInputId = deviceId;
         }
 
-        private void ChangeVideoInputSource(ChangeEventArgs args)
+        protected void OnVideoInputSourceChanged(ChangeEventArgs args)
         {
             ChangeVideoInputSource(args.Value.ToString());
         }

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
@@ -23,15 +24,15 @@ namespace BlazorBarcodeScanner.ZXing.JS
                 message);
         }
 
-        public void StartDecoding(string videoElementId, int width, int height)
+        public void StartDecoding(ElementReference video, int width, int height)
         {
             SetVideoResolution(width, height);
-            StartDecoding(videoElementId);
+            StartDecoding(video);
         }
 
-        public void StartDecoding(string videoElementId)
+        public void StartDecoding(ElementReference video)
         {
-            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.startDecoding", videoElementId);
+            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.startDecoding", video);
         }
 
         public void StopDecoding()
@@ -63,6 +64,57 @@ namespace BlazorBarcodeScanner.ZXing.JS
         {
             jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.toggleTorch");
         }
+
+        public async Task<string> Capture(ElementReference canvas)
+        {
+            var result = string.Empty;
+
+            await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.capture", "image/jpeg", canvas);
+
+            /* 
+             * Due to the size of the expected images, on .NET Core 5.0.5 it proved beneficial to 
+             * transfer the string unmarshalled rather than having it packed through the standard 
+             * mechanisms. Brief benchmarks on a recent PC over three FullHD snapshots in a row 
+             * yielded following results (in milliseconds):
+             * 
+             *  Edge 90.0.818.42:
+             *      Capturing:                  309     217     336     389
+             *      Transfer:   Marshalled      600     534     638     618
+             *                  Unmarshalled      9        3     10       4
+             *
+             *  Chrome 90.0.4430.85:
+             *      Capturing:                  334     231     338     233
+             *      Transfer:   Marshalled      571     453     466     451
+             *                  Unmarshalled     11       5      11       2
+             *                  
+             * As a consequence we try to use the unmarshalled path as often as possible.
+             */
+#if !NETSTANDARD2_1
+            if (jSRuntime is IJSUnmarshalledRuntime jS)
+            {
+                result = CaptureGetUnMarshalled(jS);
+            }
+            else
+            {
+                result = await CaptureGetMarshalled();
+            }
+#else
+            result = await CaptureGetMarshalled();
+#endif
+            return result;
+        }
+
+        private async Task<string> CaptureGetMarshalled()
+        {
+            return await jSRuntime.InvokeAsync<string>("BlazorBarcodeScanner.pictureGetBase64");
+        }
+
+#if !NETSTANDARD2_1
+        private string CaptureGetUnMarshalled(IJSUnmarshalledRuntime jS)
+        {
+            return jS.InvokeUnmarshalled<string>("BlazorBarcodeScanner.pictureGetBase64Unmarshalled");
+        }
+#endif 
 
         public static void OnBarcodeReceived(string barcodeText)
         {

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
@@ -8,7 +8,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
 {
     internal class BarcodeReaderInterop
     {
-        private IJSRuntime jSRuntime;
+        private readonly IJSRuntime jSRuntime;
 
         public BarcodeReaderInterop(IJSRuntime runtime)
         {
@@ -30,39 +30,39 @@ namespace BlazorBarcodeScanner.ZXing.JS
             StartDecoding(video);
         }
 
-        public void StartDecoding(ElementReference video)
+        public async void StartDecoding(ElementReference video)
         {
-            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.startDecoding", video);
+            await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.startDecoding", video);
         }
 
-        public void StopDecoding()
+        public async void StopDecoding()
         {
-            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.stopDecoding");
+            await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.stopDecoding");
         }
 
-        public void SetVideoInputDevice(string deviceId)
+        public async void SetVideoInputDevice(string deviceId)
         {
-            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setSelectedDeviceId", deviceId);
+            await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setSelectedDeviceId", deviceId);
         }
 
-        public void SetVideoResolution(int width, int height)
+        public async void SetVideoResolution(int width, int height)
         {
-            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setVideoResolution", width, height);
+            await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setVideoResolution", width, height);
         }
 
-        public void SetTorchOn()
+        public async void SetTorchOn()
         {
-            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setTorchOn");
+            await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setTorchOn");
         }
 
-        public void SetTorchOff()
+        public async void SetTorchOff()
         {
-            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setTorchOff");
+            await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setTorchOff");
         }
 
-        public void ToggleTorch()
+        public async void ToggleTorch()
         {
-            jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.toggleTorch");
+            await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.toggleTorch");
         }
 
         public async Task<string> Capture(ElementReference canvas)
@@ -110,7 +110,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
         }
 
 #if !NETSTANDARD2_1
-        private string CaptureGetUnMarshalled(IJSUnmarshalledRuntime jS)
+        private static string CaptureGetUnMarshalled(IJSUnmarshalledRuntime jS)
         {
             return jS.InvokeUnmarshalled<string>("BlazorBarcodeScanner.pictureGetBase64Unmarshalled");
         }

--- a/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
+++ b/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
@@ -109,7 +109,7 @@ window.BlazorBarcodeScanner = {
       /*  this.codeReader.stream.getVideoTracks()[0].applyConstraints({
             advanced: [{ torch: true }] // or false to turn off the torch
         }); */
-        console.log(`Started continous decode from camera with id ${selectedDeviceId}`);
+        console.log(`Started continous decode from camera with id ${this.selectedDeviceId}`);
     },
     stopDecoding: function () {
         this.codeReader.reset();

--- a/BlazorZXingJSApp/Client/Pages/Index.razor
+++ b/BlazorZXingJSApp/Client/Pages/Index.razor
@@ -46,4 +46,10 @@
             <button @onclick="OnVideoSourceNext">Next source</button>
         </td>
     </tr>
+    <tr>
+        <th style="vertical-align: top;"><button @onclick="CapturePicture">Capture</button></th>
+        <td>
+            <img src="@_imgSrc" style="width:100%;height:auto;@(string.IsNullOrWhiteSpace(_imgSrc) ? "display:none;" : "")" />
+        </td>
+    </tr>
 </table>

--- a/BlazorZXingJSApp/Client/Pages/Index.razor.cs
+++ b/BlazorZXingJSApp/Client/Pages/Index.razor.cs
@@ -14,6 +14,8 @@ namespace BlazorZXingJSApp.Client.Pages
         private string LocalBarcodeText;
         private int _currentVideoSourceIdx = 0;
 
+        private string _imgSrc = string.Empty;
+
         protected override void OnAfterRender(bool firstRender)
         {
             base.OnAfterRender(firstRender);
@@ -44,6 +46,12 @@ namespace BlazorZXingJSApp.Client.Pages
         private void LocalReceivedBarcodeText(BarcodeReceivedEventArgs args)
         {
             this.LocalBarcodeText = args.BarcodeText;
+            StateHasChanged();
+        }
+
+        private async void CapturePicture()
+        {
+            _imgSrc = await _reader.Capture();
             StateHasChanged();
         }
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ or with `custom parameters` ( below shows default values of parameters)
     ShowToggleTorch = "true"
     ShowVideoDeviceList="true"
     VideoWidth="300"
-    VideoHeigth="200"
-    OnCodeReceived="LocalReceivedBarcodeText"
+    VideoHeight="200"
  />
 
 ```
@@ -65,7 +64,14 @@ Note that `ShowToggleTorch` is an experimental feature.
 ### Receiving callbacks
 The library raises a custom event, whenever the barcode scanner sucessfully decoded a value from video stream. You can attach to that event using the component's Blazor `EventCallback` named `OnCodeReceived`.
 
-**Note**: Accessing `BlazorBarcodeScanner.ZXing.JS.JsInteropClass.BarcodeReceived` directly is discouraged and will be removed in the future. See the Blazor excerpt in the code block below:
+**Note**: Accessing `BlazorBarcodeScanner.ZXing.JS.JsInteropClass.BarcodeReceived` directly is discuraged and will be removed in the future. See the corresponding fragments in the code blocks below:
+```html
+<BlazorBarcodeScanner.ZXing.JS.BarcodeReader 
+    ...
+    OnCodeReceived="LocalReceivedBarcodeText"
+ />
+
+```
 ```cs
     private string LocalBarcodeText;
 
@@ -82,6 +88,7 @@ While keeping resolution low speeds up image processing, it might yield poor det
 In order to allow the application to trade speed for quality, the stream resolution can be set by the application through the following `custom parameters`:
   - StreamWidth
   - StreamHeight
+
 If set to `null` or `0`, a default (browser dependent?) resolution is applied (e.g. 640px by 480px). If set to any number `>0`, the camera stream is requested with the given setting. The settings are used as `ideal` constraint for `getUserMedia` (see [constraints doc](https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints#specifying_a_range_of_values). Doing so allows for achieving highest resolution by requesting rediculous high numbers for either dimension, causing  the browser to fall back to the maximum feasable for the device of choice.
 
 **Warning**: While increasing the stream resolution might improve your application's code reading performance, it might greatly affect the over all user experience (e.g. through a drop of the frame rate, increased CPU usage, bad battery life, ...) 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,37 @@ The library raises a custom event, whenever the barcode scanner sucessfully deco
     ...
     OnCodeReceived="LocalReceivedBarcodeText"
  />
-
 ```
+
 ```cs
     private string LocalBarcodeText;
 
     private void LocalReceivedBarcodeText(BarcodeReceivedEventArgs args)
     {
         this.LocalBarcodeText = args.BarcodeText;
+        StateHasChanged();
+    }
+```
+
+### Capturing a picture from the stream
+In some application it might be useful if a picture can be useful to take a still image of the frame that just decoded the last barcode. Therefor the component features an API call to capture such an image as base64 encoded JPEG image.
+```html
+    <BlazorBarcodeScanner.ZXing.JS.BarcodeReader @ref="_reader"
+        ...
+    />
+    <button @onclick="OnGrabFrame">Grab image</button>
+    <!-- If there is no source URL, we hide the image to avoid he "broken image" icons... -->
+    <img src="@_img"  style="@(string.IsNullOrWhiteSpace(_imgSrc) ? "display:none;" : "")" />
+```
+
+```cs
+    ...
+    private BarcodeReader _reader;
+    private string _img = string.Empty;
+
+    private void OnGrabFrame(MouseEventArgs args)
+    {
+        _imgSrc = await _reader.Capture();
         StateHasChanged();
     }
 ```


### PR DESCRIPTION
Sometimes it might be of interest to take a picture out of the video stream that is currently decoded. This pull request adds this capability to the component. 

It also refactors how the elements within the component are linked with the JavaScript code: Instead of using fixed IDs, ElementRefernce is used. Doing so should prepare the component for multiple instances (yet, there are still a couple of "singletons" left in the JS code...)

The image is transferred from JS to .NET through either a marshalled or unmarshalled channel. Unmarshalled is preferred as it's lightning fast compared to marshalled (see extensive comment in `Capture`). 

There are a couple of potential improvements left which I did not touch so far:
- Currently a frame is grabbed from the video stream. Yet ImageCapture features a [takePhoto](https://developer.mozilla.org/en-US/docs/Web/API/ImageCapture/takePhoto) call which might be able to provide even better quality still images. So it might be worth investigating in that functionality.
- `ImageCapture` appears to be unsupported by Safari and Firefox. A browser dependent polyfill has to be added to the component in order to support those platforms.