### PR TITLE
Improve video source selection and diagnostics

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -140,10 +140,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         public async Task<string> Capture()
         {
-            var start = DateTime.Now;
-            var image = await _backend.Capture(_canvas);
-            Console.WriteLine($"Captured in {(DateTime.Now - start).TotalMilliseconds} ms");
-            return image;
+            return await _backend.Capture(_canvas);
         }
 
         public void StopDecoding()

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -112,7 +112,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
             BarcodeReaderInterop.BarcodeReceived += ReceivedBarcodeText;
             if (StartCameraAutomatically && _videoInputDevices.Count > 0)
             {
-                _backend.SetVideoInputDevice(_videoInputDevices[0].DeviceId);
+                _backend.SetVideoInputDevice(SelectedVideoInputId);
                 StartDecoding();
             }
         }

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -59,7 +59,33 @@ namespace BlazorBarcodeScanner.ZXing.JS
         [Parameter]
         public EventCallback<BarcodeReceivedEventArgs> OnBarcodeReceived { get; set; }
 
-        public bool IsDecoding { get; protected set; } = false;
+        [Parameter]
+        public EventCallback<DecodingChangedArgs> OnDecodingChanged { get; set; }
+
+        private bool _isDecoding = false;
+        public bool IsDecoding
+        {
+            get
+            {
+                return _isDecoding;
+            }
+
+            protected set
+            {
+                var hasChanged = _isDecoding != value;
+
+                _isDecoding = value;
+                if (hasChanged)
+                {
+                    var args = new DecodingChangedArgs()
+                    {
+                        Sender = this,
+                        IsDecoding = _isDecoding,
+                    };
+                    OnDecodingChanged.InvokeAsync(args);
+                }
+            }
+        }
 
         public string BarcodeText { get; set; }
 

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -102,12 +102,14 @@ namespace BlazorBarcodeScanner.ZXing.JS
             StartDecoding();
         }
 
-        public void StartDecoding()
+        public async void StartDecoding()
         {
             var width = StreamWidth ?? 0;
             var height = StreamHeight ?? 0;
             _backend.StartDecoding(_video, width, height);
+            SelectedVideoInputId = await _backend.GetVideoInputDevice();
             IsDecoding = true;
+            StateHasChanged();
         }
 
         public async Task<string> Capture()
@@ -123,6 +125,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
             BarcodeReaderInterop.OnBarcodeReceived(string.Empty);
             _backend.StopDecoding();
             IsDecoding = false;
+            StateHasChanged();
         }
 
         public void UpdateResolution()
@@ -161,7 +164,6 @@ namespace BlazorBarcodeScanner.ZXing.JS
         {
             _backend.SetVideoInputDevice(deviceId);
             RestartDecoding();
-            SelectedVideoInputId = deviceId;
         }
 
         protected void OnVideoInputSourceChanged(ChangeEventArgs args)

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
@@ -45,6 +45,11 @@ namespace BlazorBarcodeScanner.ZXing.JS
             await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setSelectedDeviceId", deviceId);
         }
 
+        public async Task<string> GetVideoInputDevice()
+        {
+            return await jSRuntime.InvokeAsync<string>("BlazorBarcodeScanner.getSelectedDeviceId");
+        }
+
         public async void SetVideoResolution(int width, int height)
         {
             await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setVideoResolution", width, height);

--- a/BlazorBarcodeScanner.ZXing.JS/DecodingChangedArgs.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/DecodingChangedArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlazorBarcodeScanner.ZXing.JS
+{
+    public class DecodingChangedArgs
+    {
+        public BarcodeReader Sender;
+        public bool IsDecoding;
+    }
+}

--- a/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
+++ b/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
@@ -63,6 +63,9 @@ window.BlazorBarcodeScanner = {
     setSelectedDeviceId: function (deviceId) {
         this.selectedDeviceId = deviceId;
     },
+    getSelectedDeviceId: function () {
+        return this.selectedDeviceId;
+    },
     streamWidth: 640,
     streamHeight: 480,
     setVideoResolution: function (width, height) {
@@ -85,11 +88,11 @@ window.BlazorBarcodeScanner = {
 
         return videoConstraints;
     },
-    startDecoding: function (video) {
+    startDecoding: async function (video) {
         var videoConstraints = this.getVideoConstraints();
 
         console.log("Starting decoding with " + videoConstraints);
-        this.codeReader.decodeFromConstraints({ video: videoConstraints }, video, (result, err) => {
+        await this.codeReader.decodeFromConstraints({ video: videoConstraints }, video, (result, err) => {
             if (result) {
                 console.log(result);
                 DotNet.invokeMethodAsync('BlazorBarcodeScanner.ZXing.JS', 'ReceiveBarcode', result.text)
@@ -105,6 +108,9 @@ window.BlazorBarcodeScanner = {
                     });
             }
         });
+
+        // Make sure the actual selectedDeviceId is logged after start decoding.
+        this.selectedDeviceId = this.codeReader.stream.getVideoTracks()[0].getCapabilities()["deviceId"];
          
       /*  this.codeReader.stream.getVideoTracks()[0].applyConstraints({
             advanced: [{ torch: true }] // or false to turn off the torch

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ or with `custom parameters` ( below shows default values of parameters)
 Note that `ShowToggleTorch` is an experimental feature.
 
 ### Receiving callbacks
+#### OnCodeReceived
 The library raises a custom event, whenever the barcode scanner sucessfully decoded a value from video stream. You can attach to that event using the component's Blazor `EventCallback` named `OnCodeReceived`.
 
 **Note**: Accessing `BlazorBarcodeScanner.ZXing.JS.JsInteropClass.BarcodeReceived` directly is discuraged and will be removed in the future. See the corresponding fragments in the code blocks below:
@@ -81,6 +82,9 @@ The library raises a custom event, whenever the barcode scanner sucessfully deco
         StateHasChanged();
     }
 ```
+
+#### OnDecodingChanged
+In case you need to react on changed decoding states (e.g. hide and display the camera view in your page), you can hook up to this callback.
 
 ### Capturing a picture from the stream
 In some application it might be useful if a picture can be useful to take a still image of the frame that just decoded the last barcode. Therefor the component features an API call to capture such an image as base64 encoded JPEG image.


### PR DESCRIPTION
This PR adds the ability to the parent to 

- observe the decoding state of the component
- read back the device ID for the current video stream

It also fixes an error introduced earlier, where the default camera was set to the first source in the list rather than the one facing towards environment if nothing else was specified and removes some debug code that was accidentally PRed earlier. 