### PR TITLE
Stop decoding when disposed

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace BlazorBarcodeScanner.ZXing.JS
 {
-    public partial class BarcodeReader : ComponentBase
+    public partial class BarcodeReader : ComponentBase, IDisposable
     {
         [Parameter]
         public string Title { get; set; } = "Scan Barcode from Camera";
@@ -115,6 +115,11 @@ namespace BlazorBarcodeScanner.ZXing.JS
                 _backend.SetVideoInputDevice(SelectedVideoInputId);
                 StartDecoding();
             }
+        }
+        
+        public void Dispose()
+        {
+            StopDecoding();
         }
 
         private async Task GetVideoInputDevicesAsync()


### PR DESCRIPTION
I am embedding the barcode scanner in a dialog and noticed that the camera stays on when the dialog is dismissed.

Stopping the decoding when the component is disposed should handle that scenario.