### PR TITLE
Make sure the actually decoded frame can be captured by the application

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -10,6 +10,9 @@ namespace BlazorBarcodeScanner.ZXing.JS
     public partial class BarcodeReader : ComponentBase, IDisposable
     {
         [Parameter]
+        public bool DecodedPictureCapture { get; set; } = false;
+
+        [Parameter]
         public string Title { get; set; } = "Scan Barcode from Camera";
 
         [Parameter]
@@ -107,6 +110,8 @@ namespace BlazorBarcodeScanner.ZXing.JS
             await base.OnInitializedAsync();
 
             _backend = new BarcodeReaderInterop(JSRuntime);
+            _backend.SetLastDecodedPictureFormat(DecodedPictureCapture ? "image/jpeg" : null);
+
             await GetVideoInputDevicesAsync();
 
             BarcodeReaderInterop.BarcodeReceived += ReceivedBarcodeText;
@@ -146,6 +151,11 @@ namespace BlazorBarcodeScanner.ZXing.JS
         public async Task<string> Capture()
         {
             return await _backend.Capture(_canvas);
+        }
+
+        public async Task<string> CaptureLastDecodedPicture()
+        {
+            return await _backend.GetLastDecodedPicture();
         }
 
         public void StopDecoding()

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ The library raises a custom event, whenever the barcode scanner sucessfully deco
 In case you need to react on changed decoding states (e.g. hide and display the camera view in your page), you can hook up to this callback.
 
 ### Capturing a picture from the stream
-In some application it might be useful if a picture can be useful to take a still image of the frame that just decoded the last barcode. Therefor the component features an API call to capture such an image as base64 encoded JPEG image.
+#### Direct capture
+In some application it might be useful if a picture can be useful to take a still image of the video stream while decoding.
+Therefor the component features an API call to capture such an image as base64 encoded JPEG image.
 ```html
     <BlazorBarcodeScanner.ZXing.JS.BarcodeReader @ref="_reader"
         ...
@@ -108,6 +110,13 @@ In some application it might be useful if a picture can be useful to take a stil
         StateHasChanged();
     }
 ```
+
+##### Retrieving the picture for the last code decoded
+In some application it might be useful if a picture can be useful to take a still image of the frame that just decoded the last barcode. 
+This functionality can be enabled by setting the `DecodedPictureCapture` attribute to `true`. This will cause the component to store last image successfully decoded.
+Upon sucessful deciding (e.g. reception of `OnCodeReceived`), the picture can be accessed by invoking `CaptureLastDecodedPicture`. 
+
+**Warning**: Bear in mind that capturing those pictures might impair performance, CPU load or battery life.
 
 ### Setting stream quality
 While keeping resolution low speeds up image processing, it might yield poor detection performance due to the limited image quality.


### PR DESCRIPTION
The original capture mechanism triggers an image capture from the video stream at whatever timing the application runs with. Yet this might cause issues when the image is moving (e.g. due to focus or movement of the camera). In order to avoid this issue, the component can be enabled to deliver the actually analyzed frame rather than a snapshot taken upon callback processing.