### PR TITLE
Improve debounce by wiring back the "not found" event

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
@@ -143,7 +143,17 @@ namespace BlazorBarcodeScanner.ZXing.JS
             BarcodeReceived?.Invoke(args);
         }
 
+        public static void OnNotFoundReceived()
+        {
+            if (!string.IsNullOrEmpty(lastCode))
+            {
+                lastCode = string.Empty;
+                BarcodeNotFound?.Invoke();
+            }
+        }
+
         public static event BarcodeReceivedEventHandler BarcodeReceived;
+        public static event Action BarcodeNotFound;
     }
 
     public class BarcodeReceivedEventArgs : EventArgs

--- a/BlazorBarcodeScanner.ZXing.JS/JsInteropClass.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/JsInteropClass.cs
@@ -27,5 +27,11 @@ namespace BlazorBarcodeScanner.ZXing.JS
              * the rest of the interop from the component's client. */
             BarcodeReaderInterop.OnBarcodeReceived(barcodeText);
         }
+
+        [JSInvokable]
+        public static void ReceiveNotFound()
+        {
+            BarcodeReaderInterop.OnNotFoundReceived();
+        }
     }
 }

--- a/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
+++ b/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
@@ -107,6 +107,9 @@ window.BlazorBarcodeScanner = {
                         console.log(message);
                     });
             }
+            if (err && (err instanceof ZXing.NotFoundException)) {
+                DotNet.invokeMethodAsync('BlazorBarcodeScanner.ZXing.JS', 'ReceiveNotFound');
+            }
         });
 
         // Make sure the actual selectedDeviceId is logged after start decoding.


### PR DESCRIPTION
The original debounce mechanism suffered from a significant drawback: If a code is scanned, lost and scanned again, the application is never notified again. This change introduces ZXingJS' "not found" event to the application and the debounce mechanism for more elaborate logic.