### PR TITLE
Catch generic JS error upon failed start and wrap it in an exception

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
@@ -1,3 +1,4 @@
+using BlazorBarcodeScanner.ZXing.JS.Exceptions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System;
@@ -32,7 +33,14 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         public async void StartDecoding(ElementReference video)
         {
-            await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.startDecoding", video);
+            try
+            {
+                await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.startDecoding", video);
+            }
+            catch (JSException e)
+            {
+                throw new StartDecodingFailedException(e.Message, e);
+            }
         }
 
         public async void StopDecoding()

--- a/BlazorBarcodeScanner.ZXing.JS/Exceptions/StartDecodingFailedException.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/Exceptions/StartDecodingFailedException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace BlazorBarcodeScanner.ZXing.JS.Exceptions
+{
+    public class StartDecodingFailedException : Exception
+    {
+        public StartDecodingFailedException(string message, Exception e) : base(message, e)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Currently a generic JS exception is thrown upon a failed start. In order to simplify the API of the component, this error is converted to a component specific exception so the application does not have to rely on the underlying implementation.