### PR TITLE
Correct return channel to .NET for errors

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/JsInteropClass.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/JsInteropClass.cs
@@ -29,6 +29,14 @@ namespace BlazorBarcodeScanner.ZXing.JS
         }
 
         [JSInvokable]
+        public static void ReceiveError(object error)
+        {
+            // What to do with the knowledge that an error happened?
+            // Looking at current examples this might indicate issues with one of the decoders
+            // (namely BrowserQRCodeReader appears to throw errors occassionally...)
+        }
+
+        [JSInvokable]
         public static void ReceiveNotFound()
         {
             BarcodeReaderInterop.OnNotFoundReceived();

--- a/BlazorBarcodeScanner.ZXing.JS/JsInteropClass.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/JsInteropClass.cs
@@ -33,7 +33,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
         {
             // What to do with the knowledge that an error happened?
             // Looking at current examples this might indicate issues with one of the decoders
-            // (namely BrowserQRCodeReader appears to throw errors occassionally...)
+            // (namely BrowserQRCodeReader appears to throw errors occasionally...)
         }
 
         [JSInvokable]

--- a/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
+++ b/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
@@ -96,7 +96,6 @@ window.BlazorBarcodeScanner = {
         console.log("Starting decoding with " + videoConstraints);
         await this.codeReader.decodeFromConstraints({ video: videoConstraints }, video, (result, err) => {
             if (result) {
-                console.log(result);
                 if (this.lastPictureDecodedFormat) {
                     this.lastPictureDecoded = this.codeReader.captureCanvas.toDataURL(this.lastPictureDecodedFormat);
                 }
@@ -106,7 +105,6 @@ window.BlazorBarcodeScanner = {
                     });
             }
             if (err && !(err instanceof ZXing.NotFoundException)) {
-                console.error(err);
                 DotNet.invokeMethodAsync('BlazorBarcodeScanner.ZXing.JS', 'ReceiveError', err)
                     .then(message => {
                         console.log(message);

--- a/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
+++ b/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
@@ -107,7 +107,7 @@ window.BlazorBarcodeScanner = {
             }
             if (err && !(err instanceof ZXing.NotFoundException)) {
                 console.error(err);
-                DotNet.invokeMethodAsync('BlazorBarcodeScanner.ZXing.JS', 'ReceiveBarcode', err)
+                DotNet.invokeMethodAsync('BlazorBarcodeScanner.ZXing.JS', 'ReceiveError', err)
                     .then(message => {
                         console.log(message);
                     });


### PR DESCRIPTION
Playing around with BrowserQRCodeReader I got occasional .NET exceptions complaining about the inability to serialize `err` to a string. On the course to  get rid of some distracting console output I created a dedicated return channel for errors. Yet I do not know yet what to do with them as of now.