### PR TITLE
Fix NullException in "StopDecoding" at page load

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -151,7 +151,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
         public void StopDecoding()
         {
             BarcodeReaderInterop.OnBarcodeReceived(string.Empty);
-            _backend.StopDecoding();
+            _backend?.StopDecoding();
             IsDecoding = false;
             StateHasChanged();
         }


### PR DESCRIPTION
StopDecoding() fails in Release-Build because Exception is not handled.