### PR TITLE
Several small changes

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
@@ -56,7 +56,7 @@
                     <select class="zxing-video-select" @onchange="OnVideoInputSourceChanged">
                         @foreach (var videoInputDevice in _videoInputDevices)
                         {
-                            <option value="@videoInputDevice.DeviceId">@videoInputDevice.Label</option>
+                            <option value="@videoInputDevice.DeviceId" selected="@(SelectedVideoInputId == @videoInputDevice.DeviceId)">@videoInputDevice.Label</option>
                         }
                     </select>
                 </label>

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
@@ -17,15 +17,15 @@
         <div>
             @if (ShowStart)
             {
-                <button class="zxing-button start" @onclick="StartDecoding">Start</button>
+                <button class="zxing-button start" @onclick="StartDecodingSafe">Start</button>
             }
             @if (ShowReset)
             {
-                <button class="zxing-button stop" @onclick="StopDecoding">Stop</button>
+                <button class="zxing-button stop" @onclick="StopDecodingSafe">Stop</button>
             }
             @if (ShowToggleTorch)
             {
-                <button class="zxing-button torch" @onclick="ToggleTorch">Toggle Torch</button>
+                <button class="zxing-button torch" @onclick="ToggleTorchSafe">Toggle Torch</button>
             }
         </div>
     }

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -108,12 +108,15 @@ namespace BlazorBarcodeScanner.ZXing.JS
         protected ElementReference _video;
         protected ElementReference _canvas;
 
+        protected bool _DecodedPictureCapture;
+
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender) {
                 _backend = new BarcodeReaderInterop(JSRuntime);
                 try
                 {
+                    _DecodedPictureCapture = DecodedPictureCapture;
                     await _backend.SetLastDecodedPictureFormat(DecodedPictureCapture ? "image/jpeg" : null);
 
                     await GetVideoInputDevicesAsync();
@@ -133,6 +136,15 @@ namespace BlazorBarcodeScanner.ZXing.JS
                 {
                     await ReceivedErrorMessage(new ErrorReceivedEventArgs { Message = ex.Message });
                 }
+            }
+        }
+        
+        protected override async Task OnParametersSetAsync()
+        {
+            if (_DecodedPictureCapture != DecodedPictureCapture)
+            {
+                _DecodedPictureCapture = DecodedPictureCapture;
+                await _backend.SetLastDecodedPictureFormat(DecodedPictureCapture ? "image/jpeg" : null);
             }
         }
         

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -60,11 +60,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
         private bool _isDecoding = false;
         public bool IsDecoding
         {
-            get
-            {
-                return _isDecoding;
-            }
-
+            get => _isDecoding;
             protected set
             {
                 var hasChanged = _isDecoding != value;
@@ -86,8 +82,22 @@ namespace BlazorBarcodeScanner.ZXing.JS
         public string ErrorMessage { get; set; }
 
         public IEnumerable<VideoInputDevice> VideoInputDevices => _videoInputDevices;
+        [Parameter]
+        public EventCallback<IEnumerable<VideoInputDevice>> VideoInputDevicesChanged { get; set; }
 
-        public string SelectedVideoInputId { get; protected set; } = string.Empty;
+        private string _SelectedVideoInputId = string.Empty;
+        [Parameter]
+        public EventCallback<string> SelectedVideoInputIdChanged { get; set; }
+
+        public string SelectedVideoInputId
+        {
+            get => _SelectedVideoInputId;
+            protected set
+            {
+                _SelectedVideoInputId = value;
+                SelectedVideoInputIdChanged.InvokeAsync(value);
+            }
+        }
         
         [Inject]
         protected IJSRuntime JSRuntime { get; set; }
@@ -144,6 +154,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
         protected async Task GetVideoInputDevicesAsync()
         {
             _videoInputDevices = await _backend.GetVideoInputDevices("get");
+            await VideoInputDevicesChanged.InvokeAsync(_videoInputDevices);
         }
 
         protected async Task RestartDecoding()
@@ -257,6 +268,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         protected async Task ChangeVideoInputSource(string deviceId)
         {
+            SelectedVideoInputId = deviceId;
             await _backend.SetVideoInputDevice(deviceId);
             await RestartDecoding();
         }

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -50,6 +50,8 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         [Parameter]
         public EventCallback<BarcodeReceivedEventArgs> OnBarcodeReceived { get; set; }
+
+        [Parameter]
         public EventCallback<ErrorReceivedEventArgs> OnErrorReceived { get; set; }
 
         [Parameter]

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -87,16 +87,16 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         public IEnumerable<VideoInputDevice> VideoInputDevices => _videoInputDevices;
 
-        public string SelectedVideoInputId { get; private set; } = string.Empty;
+        public string SelectedVideoInputId { get; protected set; } = string.Empty;
         
         [Inject]
         protected IJSRuntime JSRuntime { get; set; }
 
-        private List<VideoInputDevice> _videoInputDevices;
+        protected List<VideoInputDevice> _videoInputDevices;
 
         private BarcodeReaderInterop _backend;
-        private ElementReference _video;
-        private ElementReference _canvas;
+        protected ElementReference _video;
+        protected ElementReference _canvas;
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
@@ -141,12 +141,12 @@ namespace BlazorBarcodeScanner.ZXing.JS
             }
         }
 
-        private async Task GetVideoInputDevicesAsync()
+        protected async Task GetVideoInputDevicesAsync()
         {
             _videoInputDevices = await _backend.GetVideoInputDevices("get");
         }
 
-        private async Task RestartDecoding()
+        protected async Task RestartDecoding()
         {
             await StopDecoding();
             await StartDecoding();

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
@@ -25,13 +25,13 @@ namespace BlazorBarcodeScanner.ZXing.JS
                 message);
         }
 
-        public void StartDecoding(ElementReference video, int width, int height)
+        public async Task StartDecoding(ElementReference video, int width, int height)
         {
-            SetVideoResolution(width, height);
-            StartDecoding(video);
+            await SetVideoResolution(width, height);
+            await StartDecoding(video);
         }
 
-        public async void StartDecoding(ElementReference video)
+        public async Task StartDecoding(ElementReference video)
         {
             try
             {
@@ -50,12 +50,12 @@ namespace BlazorBarcodeScanner.ZXing.JS
             }
         }
 
-        public async void StopDecoding()
+        public async Task StopDecoding()
         {
             await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.stopDecoding");
         }
 
-        public async void SetVideoInputDevice(string deviceId)
+        public async Task SetVideoInputDevice(string deviceId)
         {
             await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setSelectedDeviceId", deviceId);
         }
@@ -65,22 +65,22 @@ namespace BlazorBarcodeScanner.ZXing.JS
             return await jSRuntime.InvokeAsync<string>("BlazorBarcodeScanner.getSelectedDeviceId");
         }
 
-        public async void SetVideoResolution(int width, int height)
+        public async Task SetVideoResolution(int width, int height)
         {
             await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setVideoResolution", width, height);
         }
 
-        public async void SetTorchOn()
+        public async Task SetTorchOn()
         {
             await  jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setTorchOn");
         }
 
-        public async void SetTorchOff()
+        public async Task SetTorchOff()
         {
             await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setTorchOff");
         }
 
-        public async void ToggleTorch()
+        public async Task ToggleTorch()
         {
             await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.toggleTorch");
         }
@@ -91,7 +91,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
             return await PictureGet("capture");
         }
 
-        internal async void SetLastDecodedPictureFormat(string format)
+        internal async Task SetLastDecodedPictureFormat(string format)
         {
             await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.setLastDecodedPictureFormat", format);
         }
@@ -218,26 +218,26 @@ namespace BlazorBarcodeScanner.ZXing.JS
     public class ErrorReceivedEventArgs : EventArgs { 
         public string Message { get; set; }
     }
-    public delegate void ErrorReceivedEventHandler(ErrorReceivedEventArgs args);
+    public delegate Task ErrorReceivedEventHandler(ErrorReceivedEventArgs args);
     public class BarcodeReceivedEventArgs : EventArgs
     {
         public string BarcodeText { get; set; }
         public DateTime TimeReceived { get; set; } = new DateTime();
     }
 
-    public delegate void BarcodeReceivedEventHandler(BarcodeReceivedEventArgs args);
+    public delegate Task BarcodeReceivedEventHandler(BarcodeReceivedEventArgs args);
 
     public class DecodingActionEventArgs : EventArgs
     {
         public string DeviceId { get; set; }
     }
-    public delegate void DecodingStartedEventHandler(DecodingActionEventArgs args);
+    public delegate Task DecodingStartedEventHandler(DecodingActionEventArgs args);
 
     public class DecodingStoppedEventArgs : EventArgs
     {
         public string DeviceId { get; set; }
     }
-    public delegate void DecodingStoppedEventHandler(DecodingActionEventArgs args);
+    public delegate Task DecodingStoppedEventHandler(DecodingActionEventArgs args);
 
 
     public class VideoInputDevice

--- a/BlazorZXingJSApp/Client/Pages/Index.razor
+++ b/BlazorZXingJSApp/Client/Pages/Index.razor
@@ -1,6 +1,5 @@
 ﻿@page "/"
-@using BlazorBarcodeScanner.ZXing.JS
-@inject IJSRuntime JSRuntime
+
 <div class="container-fluid">
     <div class="row">
         <h2>BlazorBarcodeScanner Demo</h2>
@@ -15,7 +14,8 @@
             VideoHeight="540"
             StreamWidth="@StreamWidth"
             StreamHeight="@StreamHeight"
-            OnBarcodeReceived="LocalReceivedBarcodeText" />
+            OnBarcodeReceived="LocalReceivedBarcodeText"
+            OnErrorReceived="LocalReceivedError"/>
     </div>
     <div class="col-sm">
         <div>
@@ -36,6 +36,10 @@
         <div class="mt-1">
             <div><b>Custom Result</b></div>
                 <div class="alert alert-success" style="word-break: break-all;" role="alert">@(!string.IsNullOrWhiteSpace(LocalBarcodeText) ? @LocalBarcodeText : "Results will be here")</div>
+        </div>
+        <div class="mt-1">
+            <div><b>Errors</b></div>
+            <div class="alert alert-danger" style="word-break: break-all;" role="alert">@(!string.IsNullOrWhiteSpace(_lastError) ? _lastError : "Errors will be here")</div>
         </div>
         <div class="mt-1">
             <b>Custom Controls</b>

--- a/BlazorZXingJSApp/Client/Pages/Index.razor.cs
+++ b/BlazorZXingJSApp/Client/Pages/Index.razor.cs
@@ -16,6 +16,7 @@ namespace BlazorZXingJSApp.Client.Pages
         private int _currentVideoSourceIdx = 0;
 
         private string _imgSrc = string.Empty;
+        private string _lastError = string.Empty;
 
         protected override void OnAfterRender(bool firstRender)
         {
@@ -46,12 +47,13 @@ namespace BlazorZXingJSApp.Client.Pages
 
         private async Task LocalReceivedBarcodeText(BarcodeReceivedEventArgs args)
         {
-            await InvokeAsync(() => {
-                this.LocalBarcodeText = args.BarcodeText;
-                
-                StateHasChanged();
-                _reader.StopDecoding();
-            });
+            this.LocalBarcodeText = args.BarcodeText;
+            await _reader.StopDecoding();
+        }
+
+        private void LocalReceivedError(ErrorReceivedEventArgs args)
+        {
+            this._lastError = args.Message;
         }
 
         private async Task CapturePicture()
@@ -60,7 +62,7 @@ namespace BlazorZXingJSApp.Client.Pages
             StateHasChanged();
         }
 
-        private void OnVideoSourceNext(MouseEventArgs args)
+        private async Task OnVideoSourceNext(MouseEventArgs args)
         {
             var inputs = _reader.VideoInputDevices.ToList();
 
@@ -75,7 +77,7 @@ namespace BlazorZXingJSApp.Client.Pages
                 _currentVideoSourceIdx = 0;
             }
 
-            _reader.SelectVideoInput(inputs[_currentVideoSourceIdx]);
+            await _reader.SelectVideoInput(inputs[_currentVideoSourceIdx]);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ In case you need to react on changed decoding states (e.g. hide and display the 
 Library raises this event when there is a generic error happens, for example no video source available or user didn't give permissions.
 #### OnNotFoundReceived
 Library raises this event when an error happens while decoding.
+#### VideoInputDevicesChanged
+Library raises this event when the list of available input devices changes.
+#### SelectedVideoInputIdChanged
+Library raises this event when the selected video device changes.
 
 ### Capturing a picture from the stream
 #### Direct capture


### PR DESCRIPTION
Each of these is pretty small, so I hope it's alright to put them in one PR.

- [Add [Parameter] to OnErrorReceived](https://github.com/sabitertan/BlazorBarcodeScanner/commit/98d15f0c295bae176ff1bf80bb3a1066bf0b652e)
- [Change `async void` to `async Task and await everything`](https://github.com/sabitertan/BlazorBarcodeScanner/commit/4c98ab81390582dcfe814c7f93f75521e34a2e2b)  
`async void` is evil
- [Catch exceptions in all internal operations](https://github.com/sabitertan/BlazorBarcodeScanner/commit/625be87d65324bf1541efe24ea32e21dbf266ff1)  
These are not catchable by the library user, we should be careful
- [Make useful functions/members protected](https://github.com/sabitertan/BlazorBarcodeScanner/commit/04ef1cf799c70fb4468a55b061bc8234484fbe3f)  
This allows easier subclassing, e.g. someone might want to change the rendering of the reader completely
- [Bind SelectedVideoInputId and provide change events](https://github.com/sabitertan/BlazorBarcodeScanner/commit/604e0d87e98e70766eb802c292fb885cc8bd60cc)
- [Hook up disposing events and remove listeners on dispose](https://github.com/sabitertan/BlazorBarcodeScanner/commit/c97830733180bfad4079973b2617b7c9b14683b9)
- [React to DecodedPictureCapture parameter change](https://github.com/sabitertan/BlazorBarcodeScanner/commit/d955100cacb89f8e0406e356070faced14298560)

Note: I noticed that JS-.NET interaction is a bit awkward, might want to look into [instance calls](https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?view=aspnetcore-7.0#invoke-an-instance-net-method) and [interop integration](https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?view=aspnetcore-7.0#class-cs-example-invokeasync).

Closes #54, #53, 