### PR TITLE
added styling for video element and fixed issue with safari image capture

### DIFF
--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor
@@ -45,10 +45,10 @@
     <div class="zxing-video-container">
         @if (FullWidthVideo)
         {
-            <video @ref="_video"></video>
+            <video style="@VideoElementStyle" @ref="_video"></video>
         } else
         {
-            <video @ref="_video" width="@VideoWidth" height="@VideoHeight"></video>
+            <video style="@VideoElementStyle" @ref="_video" width="@VideoWidth" height="@VideoHeight"></video>
         }
 
     </div>

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReader.razor.cs
@@ -2,6 +2,7 @@
 using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace BlazorBarcodeScanner.ZXing.JS
@@ -67,6 +68,13 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         [Parameter]
         public int? StreamWidth { get; set; } = null;
+        
+        [Parameter]
+
+#if NET8_0
+        [StringSyntax("css")]
+#endif
+        public string VideoElementStyle { get; set; }
 
         [Parameter]
         public EventCallback<BarcodeReceivedEventArgs> OnBarcodeReceived { get; set; }
@@ -230,7 +238,7 @@ namespace BlazorBarcodeScanner.ZXing.JS
 
         public async Task<string> Capture()
         {
-            return await _backend.Capture(_canvas);
+            return await _backend.Capture(_canvas,_video);
         }
 
         public async Task<string> CaptureLastDecodedPicture()

--- a/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
+++ b/BlazorBarcodeScanner.ZXing.JS/BarcodeReaderInterop.cs
@@ -85,9 +85,9 @@ namespace BlazorBarcodeScanner.ZXing.JS
             await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.toggleTorch");
         }
 
-        public async Task<string> Capture(ElementReference canvas)
+        public async Task<string> Capture(ElementReference canvas, ElementReference video)
         {
-            await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.capture", "image/jpeg", canvas);
+            await jSRuntime.InvokeVoidAsync("BlazorBarcodeScanner.capture", "image/jpeg", canvas,video);
             return await PictureGet("capture");
         }
 

--- a/BlazorBarcodeScanner.ZXing.JS/BlazorBarcodeScanner.ZXing.JS.csproj
+++ b/BlazorBarcodeScanner.ZXing.JS/BlazorBarcodeScanner.ZXing.JS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <Authors>Sabit Igde, Ueli Niederer</Authors>
 	<Company />
 	<Description>Barcode Scanner component for Blazor using zxing-js Interop</Description>

--- a/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
+++ b/BlazorBarcodeScanner.ZXing.JS/wwwroot/BlazorBarcodeScanner.js
@@ -182,26 +182,17 @@ window.BlazorBarcodeScanner = {
             mediaStreamSetTorch(track, torchStatus);
         }
     },
-    capture: async function (type, canvas) {
+    capture: async function (type, canvas,video) {
         this.lastPicture = "";
 
         if (!this.codeReader.stream) {
             return "";
         }
 
-        let capture = new ImageCapture(this.codeReader.stream.getVideoTracks()[0]);
-
-        await capture.grabFrame()
-            .then(bitmap => {
-                let context = canvas.getContext('2d');
-
-                canvas.width = bitmap.width;
-                canvas.height = bitmap.height;
-
-                context.drawImage(bitmap, 0, 0, bitmap.width, bitmap.height);
-
-                this.lastPicture = canvas.toDataURL(type);
-            });
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        canvas.getContext('2d').drawImage(video, 0, 0);
+        this.lastPicture = canvas.toDataURL('image/png');
     },
     pictureGetBase64Unmarshalled: function (source) {
         let source_str = BINDING.conv_string(source);

--- a/BlazorBarcodeScanner.Zxing.Cpp/BarcodeReader.razor
+++ b/BlazorBarcodeScanner.Zxing.Cpp/BarcodeReader.razor
@@ -46,10 +46,10 @@
         <canvas id="video-canvas" width="@VideoWidth" height="@VideoHeight"> 
         @if (FullWidthVideo)
         {
-            <video @ref="_video"></video>
+            <video style="@VideoElementStyle" @ref="_video"></video>
         } else
         {
-            <video @ref="_video" width="@VideoWidth" height="@VideoHeight"></video>
+            <video style="@VideoElementStyle" @ref="_video" width="@VideoWidth" height="@VideoHeight"></video>
         }
         </canvas>
 

--- a/BlazorBarcodeScanner.Zxing.Cpp/BarcodeReader.razor.cs
+++ b/BlazorBarcodeScanner.Zxing.Cpp/BarcodeReader.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 
 namespace BlazorBarcodeScanner.ZXing.Cpp
@@ -65,6 +66,12 @@ namespace BlazorBarcodeScanner.ZXing.Cpp
         [Parameter]
         public int? StreamWidth { get; set; } = null;
 
+        [Parameter]
+#if NET8_0
+        [StringSyntax("css")]
+#endif
+        public string VideoElementStyle { get; set; } ="";
+        
         [Parameter]
         public EventCallback<BarcodeReceivedEventArgs> OnBarcodeReceived { get; set; }
 

--- a/BlazorBarcodeScanner.Zxing.Cpp/wwwroot/BlazorBarcodeScanner.js
+++ b/BlazorBarcodeScanner.Zxing.Cpp/wwwroot/BlazorBarcodeScanner.js
@@ -327,26 +327,17 @@ window.BlazorBarcodeScanner = {
             mediaStreamSetTorch(track, torchStatus);
         }
     },
-    capture: async function (type, canvas) {
+    capture: async function (type, canvas,video) {
         this.lastPicture = "";
 
         if (!this.codeReader.stream) {
             return "";
         }
 
-        let capture = new ImageCapture(this.codeReader.stream.getVideoTracks()[0]);
-
-        await capture.grabFrame()
-            .then(bitmap => {
-                let context = canvas.getContext('2d');
-
-                canvas.width = bitmap.width;
-                canvas.height = bitmap.height;
-
-                context.drawImage(bitmap, 0, 0, bitmap.width, bitmap.height);
-
-                this.lastPicture = canvas.toDataURL(type);
-            });
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        canvas.getContext('2d').drawImage(video, 0, 0);
+        this.lastPicture = canvas.toDataURL('image/png');
     },
     pictureGetBase64Unmarshalled: function (source) {
         let source_str = BINDING.conv_string(source);

--- a/BlazorZXingJSApp/Client/Pages/Index.razor
+++ b/BlazorZXingJSApp/Client/Pages/Index.razor
@@ -14,6 +14,7 @@
             VideoHeight="540"
             StreamWidth="@StreamWidth"
             StreamHeight="@StreamHeight"
+            VideoElementStyle="@VideoElementStyle"
             OnBarcodeReceived="LocalReceivedBarcodeText"
             OnErrorReceived="LocalReceivedError"/>
     </div>
@@ -32,6 +33,15 @@
                 </label>
             </div>
             <button @onclick="() => _reader.UpdateResolution()" class="btn btn-outline-primary">Update stream</button>
+        </div>
+        <div>
+            <b>Video element styling</b>
+            <div>(updates on enter or on focus loss)</div>
+            <div>
+                <label>Style:
+                    <input style="width: 7em" @bind="VideoElementStyle"  />
+                </label>
+            </div>
         </div>
         <div class="mt-1">
             <div><b>Custom Result</b></div>

--- a/BlazorZXingJSApp/Client/Pages/Index.razor.cs
+++ b/BlazorZXingJSApp/Client/Pages/Index.razor.cs
@@ -16,6 +16,7 @@ namespace BlazorZXingJSApp.Client.Pages
 
         private string _imgSrc = string.Empty;
         private string _lastError = string.Empty;
+        public string VideoElementStyle { get; set; } = "";
 
         protected override void OnAfterRender(bool firstRender)
         {


### PR DESCRIPTION
Greetings, 
I've added image styling for the video element, which would let you for example set width 100% or maybe have border radius for the video element , very useful when you have full width video element
i've also fixed an issue with Ios safari, it doesn't have ImageCapture object by default, I've passed the video element to the capture method and extracted the image from there , 
I've tested this method on another project with the exact same code and it works perfectly 
